### PR TITLE
Add `steam:queue-users-owned-apps` command for queueing all games for a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Automatically fill a [lancache](https://github.com/zeropingheroes/lancache) with
         lancache-autofill steam:queue-popular-apps [<top X apps>] [--free] [--windows=true] [--osx] [--linux]
         lancache-autofill steam:queue-users-recent-apps <steam id 64> [<steam id 64>...] [--windows=true] [--osx] [--linux]
         lancache-autofill steam:queue-users-recent-apps <steam-ids.txt> [--windows=true] [--osx] [--linux]
-        lancache-autofill steam:queue-users-owned-apps <steam id 64> [<steam id 64>...] [--include_free=true] [--windows=true] [--osx] [--linux]
-        lancache-autofill steam:queue-users-owned-apps <steam-ids.txt> [--include_free=true] [--windows=true] [--osx] [--linux]
+        lancache-autofill steam:queue-users-owned-apps <steam id 64> [<steam id 64>...] [--include_free=true] [--include_paid=true] [--windows=true] [--osx] [--linux]
+        lancache-autofill steam:queue-users-owned-apps <steam-ids.txt> [--include_free=true] [--include_paid=true] [--windows=true] [--osx] [--linux]
         
         lancache-autofill steam:show-queue [<status>]
         lancache-autofill steam:start-downloading

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Automatically fill a [lancache](https://github.com/zeropingheroes/lancache) with
         lancache-autofill steam:queue-popular-apps [<top X apps>] [--free] [--windows=true] [--osx] [--linux]
         lancache-autofill steam:queue-users-recent-apps <steam id 64> [<steam id 64>...] [--windows=true] [--osx] [--linux]
         lancache-autofill steam:queue-users-recent-apps <steam-ids.txt> [--windows=true] [--osx] [--linux]
+        lancache-autofill steam:queue-users-owned-apps <steam id 64> [<steam id 64>...] [--include_free=true] [--windows=true] [--osx] [--linux]
+        lancache-autofill steam:queue-users-owned-apps <steam-ids.txt> [--include_free=true] [--windows=true] [--osx] [--linux]
         
         lancache-autofill steam:show-queue [<status>]
         lancache-autofill steam:start-downloading

--- a/src/Commands/Steam/QueueUsersOwnedApps.php
+++ b/src/Commands/Steam/QueueUsersOwnedApps.php
@@ -104,7 +104,7 @@ class QueueUsersOwnedApps extends Command
                     $consumer->consume(1);
                     $appDetails = Steam::app()->appDetails($app->appId);
 
-                    return $appDetails->isFree;
+                    return $appDetails->isFree[0];
                 });
             }
 

--- a/src/Commands/Steam/QueueUsersOwnedApps.php
+++ b/src/Commands/Steam/QueueUsersOwnedApps.php
@@ -98,8 +98,14 @@ class QueueUsersOwnedApps extends Command
                 $apps = $apps->filter(function ($app, $key) use ($consumer) {
                     $consumer->consume(1);
                     $appDetails = Steam::app()->appDetails($app->appId);
+                    $isFree = $appDetails->isFree->get(0);
 
-                    return $appDetails->isFree[0];
+                    if (!isset($isFree)) {
+                        $this->warn('Unable to determine whether app ' . $app->name . ' (' . $app->appId . ') is free to play, skipping');
+                        return false;
+                    }
+
+                    return $isFree;
                 });
             }
 

--- a/src/Commands/Steam/QueueUsersOwnedApps.php
+++ b/src/Commands/Steam/QueueUsersOwnedApps.php
@@ -52,13 +52,8 @@ class QueueUsersOwnedApps extends Command
             $platforms[] = 'linux';
         }
 
-        if ($this->option('include_free')) {
-            $includeFree = true;
-        }
-
-        if ($this->option('include_paid')) {
-            $includePaid = true;
-        }
+        $includeFree = is_null($this->option('include_free')) || filter_var($this->option('include_free'), FILTER_VALIDATE_BOOLEAN);
+        $includePaid = is_null($this->option('include_paid')) || filter_var($this->option('include_paid'), FILTER_VALIDATE_BOOLEAN);
         $steamIds = $this->argument('steamIds');
 
         if (file_exists($steamIds[0])) {

--- a/src/Commands/Steam/QueueUsersOwnedApps.php
+++ b/src/Commands/Steam/QueueUsersOwnedApps.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Zeropingheroes\LancacheAutofill\Commands\Steam;
+
+use Illuminate\Console\Command;
+use Zeropingheroes\LancacheAutofill\Models\SteamQueueItem;
+use Steam;
+use bandwidthThrottle\tokenBucket\Rate;
+use bandwidthThrottle\tokenBucket\TokenBucket;
+use bandwidthThrottle\tokenBucket\BlockingConsumer;
+use bandwidthThrottle\tokenBucket\storage\FileStorage;
+
+class QueueUsersOwnedApps extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'steam:queue-users-owned-apps
+                            {steamIds* : One or more SteamId64(s) for the user(s) whose apps to queue, or a file containing a list}
+                            {--include_free=true : Queue played free games}
+                            {--windows=true : Queue the Windows version of the apps}
+                            {--osx : Queue the OS X version of the apps}
+                            {--linux : Queue the Linux version of the apps}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Queue all users\' Steam apps for downloading';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Add platforms depending on options
+        if ($this->option('windows')) {
+            $platforms[] = 'windows';
+        }
+
+        if ($this->option('osx')) {
+            $platforms[] = 'osx';
+        }
+
+        if ($this->option('linux')) {
+            $platforms[] = 'linux';
+        }
+
+        if ($this->option('include_free')) {
+            $includeFree = true;
+        }
+        $steamIds = $this->argument('steamIds');
+
+        if (file_exists($steamIds[0])) {
+            $steamIds = file_get_contents($steamIds[0]);
+            $steamIds = explode("\n", trim($steamIds));
+        }
+
+        array_filter($steamIds, function ($steamId) {
+            return trim($steamId);
+        });
+
+        // Rate limit requests to 200 requests every 5 minutes, to match Steam's rate limit
+        $storage = new FileStorage(base_path('steam-api.bucket')); // store state in base directory
+        $rate = new Rate(40, Rate::MINUTE); // add 40 tokens every minute (= 200 over 5 minutes)
+        $bucket = new TokenBucket(200, $rate, $storage); // bucket can never have more than 200 tokens saved up
+        $consumer = new BlockingConsumer($bucket); // if no tokens are available, block further execution until there are tokens
+        $bucket->bootstrap(200); // fill the bucket with 200 tokens initially
+
+        $chunkedSteamIds = array_chunk($steamIds, 10);
+
+        $users = [];
+        foreach($chunkedSteamIds as $chunkOf100SteamIds) {
+            $consumer->consume(1);
+            $users = array_merge($users, Steam::user($chunkOf100SteamIds[0])->GetPlayerSummaries($chunkOf100SteamIds));
+        }
+
+        foreach ($users as $user) {
+            $this->info('');
+
+            if ($user->communityVisibilityState != 3) {
+                $this->warn('Skipping user with private profile: ' . $user->personaName);
+                continue;
+            }
+
+            $consumer->consume(1);
+            $apps = Steam::player($user->steamId)->GetOwnedGames(includePlayedFreeGames: $includeFree);
+
+            if (empty($apps)) {
+                $this->warn('Skipping user who does not own any apps: ' . $user->personaName);
+                continue;
+            }
+
+            $this->info('Queuing apps owned by user: ' . $user->personaName);
+
+            foreach ($apps as $app) {
+
+                // Queue each platform separately
+                foreach ($platforms as $platform) {
+
+                    $existingQueueItem = SteamQueueItem::where('app_id', $app->appId)
+                        ->where('platform', $platform)
+                        ->first();
+
+                    if ($existingQueueItem) {
+                        $existingQueueItem->popularity++;
+                        $existingQueueItem->save();
+                        $this->warn('Steam app "' . $app->name . '" on platform "' . ucfirst($platform) . '" already in download queue');
+                        continue;
+                    }
+
+                    // Add the app to the download queue, specifying the platform and account
+                    $steamQueueItem = new SteamQueueItem;
+                    $steamQueueItem->app_id = $app->appId;
+                    $steamQueueItem->platform = $platform;
+                    $steamQueueItem->status = 'queued';
+
+                    if ($steamQueueItem->save()) {
+                        $this->info('Added Steam app "' . $app->name . '" on platform "' . ucfirst($platform) . '" to download queue');
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Commands/Steam/QueueUsersOwnedApps.php
+++ b/src/Commands/Steam/QueueUsersOwnedApps.php
@@ -89,7 +89,7 @@ class QueueUsersOwnedApps extends Command
             }
 
             $consumer->consume(1);
-            $apps = Steam::player($user->steamId)->GetOwnedGames(includePlayedFreeGames: $includeFree);
+            $apps = Steam::player($user->steamId)->GetOwnedGames(true, $includeFree);
 
             if (empty($apps)) {
                 $this->warn('Skipping user who does not own any apps: ' . $user->personaName);

--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -5,7 +5,7 @@ namespace Zeropingheroes\LancacheAutofill\Console;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Zeropingheroes\LancacheAutofill\Commands\Steam\{
-    AuthoriseAccount, Dequeue, Initialise, QueueApp, QueuePopularApps, QueueUsersRecentApps, Requeue, SearchApps, ShowQueue, StartDownloading, UpdateAppList
+    AuthoriseAccount, Dequeue, Initialise, QueueApp, QueuePopularApps, QueueUsersRecentApps, QueueUsersOwnedApps, Requeue, SearchApps, ShowQueue, StartDownloading, UpdateAppList
 };
 use Zeropingheroes\LancacheAutofill\Commands\App\{
     InitialiseDatabase, InitialiseDownloadsDirectory
@@ -28,6 +28,7 @@ class Kernel extends ConsoleKernel
         QueueApp::class,
         QueuePopularApps::class,
         QueueUsersRecentApps::class,
+        QueueUsersOwnedApps::class,
         ShowQueue::class,
         StartDownloading::class,
         AuthoriseAccount::class,

--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -28,6 +28,7 @@ class Kernel extends ConsoleKernel
         QueueApp::class,
         QueuePopularApps::class,
         QueueUsersRecentApps::class,
+        QueueUsersOwnedApps::class,
         ShowQueue::class,
         StartDownloading::class,
         AuthoriseAccount::class,


### PR DESCRIPTION
This PR adds the ability for a user to automatically enqueue all owned games with a single command. This is done in the same way as steam:queue-users-recent-apps except with a call to GetOwnedGames() instead of GetRecentlyPlayedGames().

Note that this PR does not attempt to refactor/combine duplicate code between QueueUsersRecentApps and QueueUsersOwnedApps as the opportunity extends to a few existing classes.

Fixes #49. Fixes #53. I was interested in this functionality as well and decided to give it a go.

Also fixes #55 with latest enhancements.