### PR TITLE
Update install.sh for buster/bullseye compat

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@ BLACK='\033[0m'
 
 printf "${GREEN}Installing apt package dependencies${BLACK}\n"
 sudo apt update -y
-sudo apt install -y lib32gcc1 lib32stdc++6 lib32tinfo5 lib32ncurses5 composer expect zip unzip \
-                    php7.2-cli php7.2-mbstring php7.2-sqlite \php7.2-bcmath php7.2-dom
+sudo apt install -y lib32gcc1 lib32stdc++6 lib32tinfo6 lib32ncurses6 composer expect zip unzip \
+                    php-cli php-mbstring php-sqlite3 php-bcmath php-dom
 
 printf "${GREEN}Installing PHP dependencies with Composer${BLACK}\n"
 cd $SCRIPT_DIR && composer install


### PR DESCRIPTION
- Replace lib32tinfo5 with lib32tinfo6
- Replace lib32ncurses5 with lib32ncurses6
- replace PHP7.2 modules with generic ones, to always install recent (currently 7.3)